### PR TITLE
Including ant targets from imported files

### DIFF
--- a/tabcomplete.ps1
+++ b/tabcomplete.ps1
@@ -1,21 +1,31 @@
 if ((Test-Path Function:\TabExpansion) -and (-not (Test-Path Function:\PrevTabExpansion))) {
-    Rename-Item Function:\TabExpansion PrevTabExpansion
+  Rename-Item Function:\TabExpansion PrevTabExpansion
 }
 
-function AntTabExpansion($buildFile, $lastWord) {
-  return Select-Xml -path ./$buildFile -xpath "//target[@name]"| foreach { $_.Node.name } | Where-Object { ($_ -notlike "-*") -and ($_ -like "$lastWord*") } | Sort
+function AntTabExpansion ($buildFile,$lastWord) {
+  $buildFileDir = [regex]::Match($buildFile,'^(.+)/([^/]+)$').captures.groups[1].value
+  if ($buildFileDir) { $buildFileDir += "/" }
+  $targets = Select-Xml -Path ./$buildFile -XPath "//target[@name]" | ForEach-Object { $_.Node.Name }
+  $importedTargets = @()
+  $importedBuildFiles = Select-Xml -Path ./$buildFile -XPath "//import[@file]" | ForEach-Object { $_.Node.file }
+  foreach ($importedBuildFile in $importedBuildFiles) {
+    $isAbsolutePath = $importedBuildFile -match '/^(?:[A-Za-z]:)?\\/'
+    if (!$isAbsolutePath) { $importedBuildFile = $buildFileDir + $importedBuildFile }
+    $importedTargets += AntTabExpansion ($importedBuildFile,$lastWord)
+  }
+  return $targets + $importedTargets | Where-Object { ($_ -notlike "-*") -and ($_ -like "$lastWord*") } | Sort
 }
 
-function TabExpansion($line, $lastWord) {
-    $lastBlock = [regex]::Split($line, '[|;]')[-1].TrimStart()
+function TabExpansion ($line,$lastWord) {
+  $lastBlock = [regex]::Split($line,'[|;]')[-1].TrimStart()
 
-    switch -regex ($lastBlock) {
-	# Execute ant tab completion for non standard ant files  
-	"ant -f (.*\.xml) (.*)" {AntTabExpansion $matches[1] $lastWord; break}
-        # Execute ant tab completion for all ant targets
-        "ant (.*)" { AntTabExpansion "build.xml" $lastWord; break }
+  switch -regex ($lastBlock) {
+    # Execute ant tab completion for non standard ant files  
+    "ant -f (.*\.xml) (.*)" { AntTabExpansion $matches[1] $lastWord; break }
+    # Execute ant tab completion for all ant targets
+    "ant (.*)" { AntTabExpansion "build.xml" $lastWord; break }
 
-        # Fall back on existing tab expansion
-        default { if (Test-Path Function:\PrevTabExpansion) { PrevTabExpansion $line $lastWord } }
-    }
+    # Fall back on existing tab expansion
+    default { if (Test-Path Function:\PrevTabExpansion) { PrevTabExpansion $line $lastWord } }
+  }
 }


### PR DESCRIPTION
Now including ant targets from imported files in the set of autocomplete results.

One issue I'm aware of is that importing files with properties in the name doesn't work, e.g.

```xml
<property name="someLocation" location="somewhere"/>

<import file="${someLocation}/someOtherBuild.xml/>
```

Targets in `somehwere/someOtherBuild.xml` won't be included. I may look in to this later as it's a bit of a nuisance.

I also formatted the script using [PowerShell Beautifier](https://github.com/DTW-DanWard/PowerShell-Beautifier). Wasn't sure what the style preference was.